### PR TITLE
Use vcpkg master branch by default

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,7 +10,12 @@ set VCPKG_DEFAULT_TRIPLET=x64-windows
 
 if not exist vcpkg git clone https://github.com/Microsoft/vcpkg.git
 cd .\vcpkg\
-git checkout 2023.02.24
+
+rem By default we use the master branch of vcpkg.
+rem The last successfully tested vcpkg release was 2023.07.21.
+rem Uncomment the next line to use this specific release of vcpkg (this might help if the current master branch of vcpkg makes problems)
+rem git checkout 2023.07.21
+
 if not exist vcpkg.exe call .\bootstrap-vcpkg.bat
 call .\vcpkg.exe install libxml2 zlib
 cd ..


### PR DESCRIPTION
We originally thought that it might be a good idea to use a tested release of vcpkg in the provided build.bat script.
However, it turned out that vcpkg releases get outdated more often then expected mainly due to changed external dependencies.
Typically, these broken links get fixed quickly in the master branch of vcpkg.
Hence, we will now switch to the master branch of vpkg by default.

Note: In case the master branch causes problems, just one line in the build.bat file needs to be changed to switch to a specific release of vcpkg.

This PR fixes #13.