### PR TITLE
Find python interpreter automatically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(cmake/fmi-library)
 
 find_package(LibXml2 REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package (Python COMPONENTS Interpreter Development)
 
 # global project settings
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,6 @@ set -euo pipefail
 # apt update
 # apt install -y cmake git
 # apt install -y build-essential
-# apt install -y python-is-python3
 # apt install -y libxml2-dev zlib1g-dev
 
 mkdir -p build

--- a/cmake/sspschemafiles.cmake
+++ b/cmake/sspschemafiles.cmake
@@ -19,7 +19,7 @@
 # function used to generate custom command comment
 function(gen_cmd_comment CMD_COMMENT SCHEMA_FILE PYTHON_SCRIPT OUTPUT_DIR PREFIX OUTPUT_FILE)
     set(COMMENT "Processing ${SCHEMA_FILE}:")
-    set(COMMENT "${COMMENT} python")
+    set(COMMENT "${COMMENT} ${Python_EXECUTABLE}")
     set(COMMENT "${COMMENT} ${PYTHON_SCRIPT}")
     set(COMMENT "${COMMENT} ${SCHEMA_FILE}")
     set(COMMENT "${COMMENT} -o ${OUTPUT_DIR}")
@@ -61,7 +61,7 @@ foreach(SCHEMA_FILE ${SCHEMA_FILES})
 
         add_custom_command(
             OUTPUT "${OUT_DIR}/${SUB_DIR}/${SCHEMA_FILE_NAME}.h"
-            COMMAND python "${PYTHON_SCRIPT}" "${SCHEMA_FILE}" -o "${OUT_DIR}/${SUB_DIR}" -p "${SUB_DIR}"
+            COMMAND "${Python_EXECUTABLE}" "${PYTHON_SCRIPT}" "${SCHEMA_FILE}" -o "${OUT_DIR}/${SUB_DIR}" -p "${SUB_DIR}"
             DEPENDS "${SCHEMA_FILE}"
             COMMENT "${CMD_COMMENT}")
 
@@ -77,7 +77,7 @@ foreach(SCHEMA_FILE ${SCHEMA_FILES})
 
         add_custom_command(
             OUTPUT "${OUT_DIR}/${SCHEMA_FILE_NAME}.h"
-            COMMAND python "${PYTHON_SCRIPT}" "${SCHEMA_FILE}" -o "${OUT_DIR}"
+            COMMAND "${Python_EXECUTABLE}" "${PYTHON_SCRIPT}" "${SCHEMA_FILE}" -o "${OUT_DIR}"
             DEPENDS "${SCHEMA_FILE}"
             COMMENT "${CMD_COMMENT}")
 


### PR DESCRIPTION
Strictly following the readme on a fresh Ubuntu 22.04 will not build openmcx as `python` cannot be found. 

Instead of relying on `python-is-python3` (which is not mentioned in the readme) there is a cmake function to find an installed python interpreter. According to the [manual](https://cmake.org/cmake/help/v3.22/module/FindPython.html) this function was introduced in cmake 3.12 and openmcx already requires > 3.14.  

I tested this on my fresh 22.04 installation. 


